### PR TITLE
Return the created_at field in the find results

### DIFF
--- a/api.py
+++ b/api.py
@@ -68,6 +68,7 @@ def find_malware():
                  "sha512" : row.sha512,
                  "crc32" : row.crc32,
                  "ssdeep": row.ssdeep,
+                 "created_at": row.created_at.__str__(),
                  "tags" : tags}
 
         return entry


### PR DESCRIPTION
When the patch for adding created_at was rewritted the return results in
find were removed. This adds the created at back in using pythons
default string rentering on datetime.
